### PR TITLE
layers/meta-rockchip: Use non-authenticated fetch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,4 +15,4 @@
 	url = https://github.com/balena-os/poky
 [submodule "layers/meta-rockchip"]
 	path = layers/meta-rockchip
-	url = git@github.com:clodpi/meta-rockchip.git
+	url = https://github.com/clodpi/meta-rockchip.git


### PR DESCRIPTION
The meta-rockchip module is currently using SSH authentication which
versiobot does not support.

Changelog-entry: Use non-authenticated fetch with meta-rockchip module
Signed-off-by: Alex Gonzalez <alexg@balena.io>