### PR TITLE
meta-balena-rockchip: update local.conf.sample

### DIFF
--- a/layers/meta-balena-rockchip/conf/samples/local.conf.sample
+++ b/layers/meta-balena-rockchip/conf/samples/local.conf.sample
@@ -8,8 +8,8 @@ BALENA_STORAGE = "overlay2"
 #TARGET_REPOSITORY ?= ""
 #TARGET_TAG ?= ""
 
-# Set this to 1 if development image is desired
-#DEVELOPMENT_IMAGE = "1"
+# Set this to 1 to disable quiet boot and allow bootloader shell access
+#OS_DEVELOPMENT = "1"
 
 # Set this to make build system generate balenahup bundles
 #RESINHUP ?= "yes"


### PR DESCRIPTION
Update the sample configuration file to use OS_DEVELOPMENT instead of DEVELOPMENT_IMAGE.

Change-type: patch
Changelog-entry: meta-balena-rockchip: update local.conf.sample
Signed-off-by: Mark Corbin <mark@balena.io>