### PR TITLE
layers/meta-rockchip: Fix https protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = https://github.com/balena-os/poky
 [submodule "layers/meta-rockchip"]
 	path = layers/meta-rockchip
-	url = https://github.com/clodpi/meta-rockchip.git
+	url = https://github.com/acostach/meta-rockchip.git
 [submodule "contracts"]
 	path = contracts
 	url = https://github.com/balena-io/contracts.git


### PR DESCRIPTION
We temporarily switch to my personal repository
which adds https protocol to github URIs, so
we can check if there are other build failures.

Changelog-entry: layers/meta-rockchip: Fix https protocol
Signed-off-by: Alexandru Costache <alexandru@balena.io>